### PR TITLE
Fix VirtualMachineConfig.Startup property

### DIFF
--- a/api/qemu_type.go
+++ b/api/qemu_type.go
@@ -400,7 +400,7 @@ type VirtualMachineCreateOptions struct {
 	// cloud-init setup public ssh keys (one key per line, OpenSSH format)
 	SSHKeys   string `json:"sshkeys,omitempty"`
 	StartDate string `json:"startdate,omitempty"`
-	StartUp   int8   `json:"startup,omitempty"`
+	StartUp   string `json:"startup,omitempty"`
 	Storage   string `json:"storage,omitempty"`
 	Tablet    int8   `json:"tablet,omitempty"`
 	// tags of the VM. only for meta information


### PR DESCRIPTION
As per the PVE API docs, the `startup` property is a string rather than an int, this is currently breaking the cloud controller on my cluster due to failing to process the json. This simply swaps that type to `string` to match. 
https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/config